### PR TITLE
JPEG images with DQT marker support

### DIFF
--- a/docx/image/__init__.py
+++ b/docx/image/__init__.py
@@ -11,7 +11,7 @@ from __future__ import (
 
 from docx.image.bmp import Bmp
 from docx.image.gif import Gif
-from docx.image.jpeg import Exif, Jfif
+from docx.image.jpeg import Exif, Jfif, Dqt
 from docx.image.png import Png
 from docx.image.tiff import Tiff
 from docx.image.svg import Svg
@@ -19,6 +19,7 @@ from docx.image.svg import Svg
 
 SIGNATURES = (
     # class, offset, signature_bytes
+    (Dqt, 0, b'\xFF\xD8'),
     (Png,  0, b'\x89PNG\x0D\x0A\x1A\x0A'),
     (Jfif, 6, b'JFIF'),
     (Exif, 6, b'Exif'),

--- a/docx/image/jpeg.py
+++ b/docx/image/jpeg.py
@@ -7,6 +7,8 @@ sub-formats.
 
 from __future__ import absolute_import, division, print_function
 
+import PIL
+
 from ..compat import BytesIO
 from .constants import JPEG_MARKER_CODE, MIME_TYPE
 from .helpers import BIG_ENDIAN, StreamReader
@@ -71,6 +73,27 @@ class Jfif(Jpeg):
         px_height = markers.sof.px_height
         horz_dpi = markers.app0.horz_dpi
         vert_dpi = markers.app0.vert_dpi
+
+        return cls(px_width, px_height, horz_dpi, vert_dpi)
+
+
+class Dqt(Jpeg):
+    """
+    Image header parser for Jpeg with marker Dqt image format
+    """
+    @classmethod
+    def from_stream(cls, stream):
+        """
+        Create a Dqt instance from an image stream.
+
+        This method uses Pillow to open the image and extract its metadata.
+        It's particularly useful for JPEG images that don't conform to standard
+        JFIF or Exif formats but can still be processed by Pillow.
+
+        """
+        img = PIL.Image.open(stream)
+        px_width, px_height = img.size
+        horz_dpi, vert_dpi = img.info.get("dpi", (144, 144))
 
         return cls(px_width, px_height, horz_dpi, vert_dpi)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-Willow==1.5.1
 behave>=1.2.3
 flake8>=2.0
 lxml>=3.1.0
 mock>=1.0.1
+pillow~=10.4.0
 pyparsing>=2.0.1
 pytest>=2.5
+Willow==1.5.1


### PR DESCRIPTION
- Implement Dqt class to handle JPEG images with Define Quantization Table marker
- Use Pillow library to extract image metadata for non-standard JPEG formats
- Update image parsing logic to recognize and process DQT-marked JPEG files
- Enhance compatibility with various JPEG formats in document processing

This change improves the library's ability to handle a wider range of JPEG images, particularly those that don't conform to standard JFIF or Exif formats.